### PR TITLE
Use new GeoTools repository

### DIFF
--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -59,9 +59,11 @@
 
 	<repositories>
 		<repository>
-			<id>osgeo</id>
-			<name>Open Source Geospatial Foundation Repository</name>
-			<url>http://download.osgeo.org/webdav/geotools/</url>
+		    <id>osgeo</id>
+		    <name>OSGeo Release Repository</name>
+		    <url>https://repo.osgeo.org/repository/release/</url>
+		    <snapshots><enabled>false</enabled></snapshots>
+		    <releases><enabled>true</enabled></releases>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
Build is failing due to the old OSGeo Maven repository being deprecated. PR updates repository definition with new `url` and with `snapshots` and `releases` parameters.

More info about the new repository: https://www.osgeo.org/foundation-news/new-osgeo-repo/

Fixes #32 